### PR TITLE
Update check-pinnable-docker-file-only.yaml

### DIFF
--- a/.github/workflows/check-pinnable-docker-file-only.yaml
+++ b/.github/workflows/check-pinnable-docker-file-only.yaml
@@ -11,15 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c    
-      - run: pwd
-      #- run: cat .git/config
-      - uses: cider-research-testing/action-docker-file-only@main
-      - uses: cider-research-testing/unpinnable-action@main
+      - uses: cider-research-testing/unpinnable-action@809b27f9d264dcc93f0984fe025697b52f49eccf
         with:
          token: ${{ secrets.db_password }}
-      - name: Labeler
-        uses: actions/labeler@v4.0.3
-
-
-
-                  


### PR DESCRIPTION
Here is a simple footnote[^1].

A footnote can also have multiple lines[^2].  

You can also use words, to fit your writing style more closely[^note].

[^1]: My reference.
[^2]: Every new line should be prefixed with 2 spaces.  
  This allows you to have a footnote with multiple lines.
[^note]:
    Named footnotes will still render with numbers instead of the text but allow easier identification and linking.  
    This footnote also has been made with a different syntax using 4 spaces for new lines.
